### PR TITLE
Fix #5 by partially replacing #1 fix (db6c7a7) with simpler one.

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,20 +31,13 @@ function GulpLL () {
 
 
 GulpLL.prototype._getWorkerArgs = function (task) {
-    var ll      = this;
-    var taskIdx = null;
+    var ll = this;
 
-    var args = this.args.filter(function (arg, idx) {
-        var isTaskArg = ll.allTasks.indexOf(arg) > -1;
-
-        if (isTaskArg && taskIdx === null)
-            taskIdx = idx;
-
-        return !isTaskArg;
+    var args = this.args.filter(function (arg) {
+        return ll.allTasks.indexOf(arg) < 0;
     });
 
-    args.splice(taskIdx === null ? args.length : taskIdx, 0, 'worker:' + task);
-
+    args.splice(1, 0, 'worker:' + task);
     args.push('--ll-worker');
 
     if (this.isDebug)

--- a/test/test.js
+++ b/test/test.js
@@ -68,3 +68,8 @@ test("Regression - Gulp task is failed when it's run with the --dev argument (GH
     // NOTE: smoke test, this should pass without error
     return runGulp('task3 --dev');
 });
+
+test('Regression - Gulp fails when a flag is specified without tasks (GH-5)', function () {
+    // NOTE: smoke test, this should pass without error
+    return runGulp('--dev');
+});


### PR DESCRIPTION
Also add the failing test from #5 which now passes.

Compared to the version before the original #1 fix in db6c7a7, the diff looks simply like:

```diff
diff --git index.js index.js
index 55f1a7a..d73c303 100644
--- index.js
+++ index.js
@@ -37,7 +37,7 @@ GulpLL.prototype._getWorkerArgs = function (task) {
         return ll.allTasks.indexOf(arg) < 0;
     });
 
-    args.push('worker:' + task);
+    args.splice(1, 0, 'worker:' + task);
     args.push('--ll-worker');
 
     if (this.isDebug)
```