### PR TITLE
Basic Gulp v4 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,6 +77,10 @@ GulpLL.prototype._overrideGulpTaskFn = function () {
 
         if (ll._isLLTask(name)) {
             if (ll.isWorker) {
+                // Also define a task under the original name so gulp's task validation will not complain
+                ll.taskFn(name, function () {
+                    throw new Error('Original task should not be executed in the worker');
+                });
                 deps = void 0;
                 name = 'worker:' + name;
             }
@@ -89,7 +93,11 @@ GulpLL.prototype._overrideGulpTaskFn = function () {
 
 
         ll.allTasks.push(name);
-        ll.taskFn(name, deps, fn);
+        if (deps) {
+            ll.taskFn(name, deps, fn);
+        } else {
+            ll.taskFn(name, fn);
+        }
     };
 };
 


### PR DESCRIPTION
Key issues with Gulp v4 are: `gulp.task` *never* takes a `deps` argument (deps are now done via `gulp.task('foo', gulp.series('dep', fn))`, and all task dependencies must be defined, even if not called in a context (e.g. in the worker process, can't rename a task without also leaving something under the old name (which will never be called) for gulp's validation code to find).

This change should keep this module compatible with both Gulp v3 and v4.

After fixing the Gulp v4 issues, adding the one line of `require('gulp-ll').tasks(['eslint'])` nearly cut my build times in half, thanks!